### PR TITLE
calendar

### DIFF
--- a/05-lection3/03-calendar/calendar.css
+++ b/05-lection3/03-calendar/calendar.css
@@ -1,0 +1,84 @@
+.calendar {
+    padding: 28px 26px 32px;
+    background: var(--white);
+    /* Gray 3 */
+
+    border: 1px solid var(--grey-3);
+    border-radius: 8px;
+
+    max-width: 300px;
+}
+
+.calendar__title {
+    text-align: center;
+
+    font-family: 'Inter';
+    font-style: normal;
+    font-weight: 600;
+    font-size: 20px;
+    line-height: 24px;
+    /* identical to box height, or 120% */
+
+    color: var(--dark-blue-1);
+}
+
+.calendar__item {
+
+    font-family: 'Source Sans Pro';
+    font-style: normal;
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 20px;
+    /* identical to box height, or 125% */
+
+
+    /* #334D6E */
+
+    color: var(--dark-blue-1);
+
+    position: relative;
+    text-align: center;
+}
+
+.calendar__cell {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translateY(-50%) translateX(-50%);
+}
+
+.calendar__item_empty-before {
+    grid-area: 2 / 1 / 3 / 6;
+}
+
+.calendar__item_pick {
+    background: var(--blue-alt-1);
+    color: var(--white);
+}
+
+.calendar__item_between-pick {
+    background: var(--blue-light-1);
+    /* opacity: 0.2; */
+}
+
+.calendar__wrapper {
+    margin-top: 24px;
+    position: relative;
+    padding-bottom: 100%;
+}
+
+.calendar__inner {
+    display: grid;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    grid-template-columns: repeat(7, 1fr);
+    grid-template-rows: repeat(7, 1fr);
+    justify-items: stretch;
+    align-items: stretch;
+
+
+
+}

--- a/05-lection3/03-calendar/calendar.css
+++ b/05-lection3/03-calendar/calendar.css
@@ -36,16 +36,13 @@
 
     color: var(--dark-blue-1);
 
-    position: relative;
-    text-align: center;
+    /* text-align: center; */
+    display: flex; 
+    align-items: center; 
+    justify-content: center
 }
 
-.calendar__cell {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translateY(-50%) translateX(-50%);
-}
+
 
 .calendar__item_empty-before {
     grid-area: 2 / 1 / 3 / 6;

--- a/05-lection3/03-calendar/index.html
+++ b/05-lection3/03-calendar/index.html
@@ -7,6 +7,114 @@
         <title>Calendar</title>
     </head>
     <body>
+        <div class="calendar">
+            <div class="calendar__title">October 2022</div>
+            <div class="calendar__wrapper">
+                <div class="calendar__inner">
+                    <div class="calendar__item calendar__item_day">Mon</div>
+                    <div class="calendar__item calendar__item_day">Tue</div>
+                    <div class="calendar__item calendar__item_day">Wed</div>
+                    <div class="calendar__item calendar__item_day">Thu</div>
+                    <div class="calendar__item calendar__item_day">Fri</div>
+                    <div class="calendar__item calendar__item_day">Sat</div>
+                    <div class="calendar__item calendar__item_day">Sun</div>
+                    <div class="calendar__item calendar__item_empty-before"></div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">1</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">2</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">3</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">4</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">5</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">6</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">7</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">8</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">9</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">10</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">11</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">12</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">13</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">14</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">15</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">16</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">17</div>
+                    </div>
+                    <div class="calendar__item calendar__item_pick">
+                        <div class="calendar__cell">18</div>
+                    </div>
+                    <div class="calendar__item calendar__item_between-pick">
+                        <div class="calendar__cell">19</div>
+                    </div>
+                    <div class="calendar__item calendar__item_between-pick">
+                        <div class="calendar__cell">20</div>
+                    </div>
+                    <div class="calendar__item calendar__item_between-pick">
+                        <div class="calendar__cell">21</div>
+                    </div>
+                    <div class="calendar__item calendar__item_between-pick">
+                        <div class="calendar__cell">22</div>
+                    </div>
+                    <div class="calendar__item calendar__item_pick">
+                        <div class="calendar__cell">23</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">24</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">25</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">26</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">27</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">28</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">29</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">30</div>
+                    </div>
+                    <div class="calendar__item">
+                        <div class="calendar__cell">31</div>
+                    </div>
+                </div>
+            </div>
+        </div>
 
     </body>
 </html>

--- a/05-lection3/03-calendar/index.html
+++ b/05-lection3/03-calendar/index.html
@@ -19,99 +19,37 @@
                     <div class="calendar__item calendar__item_day">Sat</div>
                     <div class="calendar__item calendar__item_day">Sun</div>
                     <div class="calendar__item calendar__item_empty-before"></div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">1</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">2</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">3</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">4</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">5</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">6</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">7</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">8</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">9</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">10</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">11</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">12</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">13</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">14</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">15</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">16</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">17</div>
-                    </div>
-                    <div class="calendar__item calendar__item_pick">
-                        <div class="calendar__cell">18</div>
-                    </div>
-                    <div class="calendar__item calendar__item_between-pick">
-                        <div class="calendar__cell">19</div>
-                    </div>
-                    <div class="calendar__item calendar__item_between-pick">
-                        <div class="calendar__cell">20</div>
-                    </div>
-                    <div class="calendar__item calendar__item_between-pick">
-                        <div class="calendar__cell">21</div>
-                    </div>
-                    <div class="calendar__item calendar__item_between-pick">
-                        <div class="calendar__cell">22</div>
-                    </div>
-                    <div class="calendar__item calendar__item_pick">
-                        <div class="calendar__cell">23</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">24</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">25</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">26</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">27</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">28</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">29</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">30</div>
-                    </div>
-                    <div class="calendar__item">
-                        <div class="calendar__cell">31</div>
-                    </div>
+                    <div class="calendar__item">1</div>
+                    <div class="calendar__item">2</div>
+                    <div class="calendar__item">3</div>
+                    <div class="calendar__item">4</div>
+                    <div class="calendar__item">5</div>
+                    <div class="calendar__item">6</div>
+                    <div class="calendar__item">7</div>
+                    <div class="calendar__item">8</div>
+                    <div class="calendar__item">9</div>
+                    <div class="calendar__item">10</div>
+                    <div class="calendar__item">11</div>
+                    <div class="calendar__item">12</div>
+                    <div class="calendar__item">13</div>
+                    <div class="calendar__item">14</div>
+                    <div class="calendar__item">15</div>
+                    <div class="calendar__item">16</div>
+                    <div class="calendar__item">17</div>
+                    <div class="calendar__item calendar__item_pick">18</div>
+                    <div class="calendar__item calendar__item_between-pick">19</div>
+                    <div class="calendar__item calendar__item_between-pick">20</div>
+                    <div class="calendar__item calendar__item_between-pick">21</div>
+                    <div class="calendar__item calendar__item_pick">22</div>
+                    <div class="calendar__item">23</div>
+                    <div class="calendar__item">24</div>
+                    <div class="calendar__item">25</div>
+                    <div class="calendar__item">26</div>
+                    <div class="calendar__item">27</div>
+                    <div class="calendar__item">28</div>
+                    <div class="calendar__item">29</div>
+                    <div class="calendar__item">30</div>
+                    <div class="calendar__item">31</div>
                 </div>
             </div>
         </div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -18,6 +18,9 @@
     --grey-2: #DDE2E5;
     --grey-3: #ACB5BD;
     --grey-4: #495057;
+    --dark-blue-1: #334D6E;
+    --blue-alt-1: #4263EB;
+    --blue-light-1: #a0b1f531;
 
     --error: var(--red);
     --success: var(--blue);

--- a/assets/fonts/fonts.css
+++ b/assets/fonts/fonts.css
@@ -1,2 +1,3 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&family=Source+Sans+Pro:wght@200;300;400;600;700;900&display=swap');


### PR DESCRIPTION
очень сильно попотел по поводу позиционирования цифр в ячейках, типа justify/align-items выставлял stretch, но текст внутри не выравнивался. Если задавать не стретч, а центр, тогда контент выравнивается, но размер контента меньше размера ячейки => при задавании bgc цвет появляется только у контента. 